### PR TITLE
Allow gasPrice to be set in payment URL data

### DIFF
--- a/src/app/pay-with-request/pay-with-request.component.ts
+++ b/src/app/pay-with-request/pay-with-request.component.ts
@@ -21,6 +21,7 @@ export class PayWithRequestComponent implements OnInit {
   requestNetworkId: number;
   queryParamError: boolean;
   redirectUrl: string;
+  gasPrice: number;
   max: number;
   min: number;
   date = new Date();
@@ -54,6 +55,9 @@ export class PayWithRequestComponent implements OnInit {
 
     this.callbackUrl = queryParams.callbackUrl;
     this.requestNetworkId = queryParams.networkId;
+    this.gasPrice = ('gasPrice' in queryParams)
+      ? queryParams.gasPrice
+      : this.web3Service.defaultGasPrice;
 
     // reload requestObject with its web3 if account has changed
     this.web3Service.accountObservable.subscribe(account => {
@@ -170,7 +174,8 @@ export class PayWithRequestComponent implements OnInit {
         autoFocus: false,
         data: {
           callbackTx,
-          signedRequestObject: this.signedRequestObject
+          signedRequestObject: this.signedRequestObject,
+          gasPrice: this.gasPrice
         }
       })
       .afterClosed()

--- a/src/app/util/dialogs/broadcast-dialog.component.ts
+++ b/src/app/util/dialogs/broadcast-dialog.component.ts
@@ -18,6 +18,7 @@ export class BroadcastDialogComponent implements OnInit {
   allowanceMode: boolean;
   isAllowanceGranted: boolean;
   callbackTx: any;
+  gasPrice: number
 
   constructor(
     public web3Service: Web3Service,
@@ -28,6 +29,7 @@ export class BroadcastDialogComponent implements OnInit {
     this.callbackTx = data.callbackTx;
     this.signedRequestObject = data.signedRequestObject;
     this.requestData = data.signedRequestObject.signedRequestData;
+    this.gasPrice = data.gasPrice;
     this.loading = false;
     this.isAllowanceGranted = false;
 
@@ -69,7 +71,13 @@ export class BroadcastDialogComponent implements OnInit {
     this.web3Service
       .broadcastSignedRequestAsPayer(
         this.signedRequestObject,
-        this.requestData.expectedAmounts
+        this.requestData.expectedAmounts,
+        {
+          transactionOptions: {
+            gasPrice: this.gasPrice,
+            skipERC20checkAllowance: true
+      }
+    }
       )
       .on('broadcasted', response => {
         this.dialogRef.close(response.transaction.hash);

--- a/src/app/util/web3.service.ts
+++ b/src/app/util/web3.service.ts
@@ -27,7 +27,7 @@ export class Web3Service {
     1: 'https://mainnet.infura.io/BQBjfSi5EKSCQQpXebO',
     4: 'https://rinkeby.infura.io/BQBjfSi5EKSCQQpXebO'
   };
-  private defaultGasPrice = 10000000000; // 10 gwei
+  public defaultGasPrice = 10000000000; // 10 gwei
 
   public metamask = false;
   public ledgerConnected = false;


### PR DESCRIPTION
Hi Elliott,

For the tip bot it would be helpful if I could specify the gas price - they are just tips so it doesn't matter if it takes longer for them to be confirmed. This (untested :-) ) PR should expose that functionality, so I can include `gasPrice` in the JSON/base64 data I send with the payment URL.

Longer term it would be useful if I could specify a "gas profile" (e.g. low, medium, high), and then the app would use ethgasstation to figure out sensible values for each category.

I made web3service.defaultGasPrice public so it can be reused as the default if the user does not include gasPrice in the URL data.

Please consider merging this if the implementation is sound.

Thanks,

Mike