### PR TITLE
feat: added builderId to advance invoices and regular requests

### DIFF
--- a/src/app/invoices/advanced-invoice/advanced-invoice.component.ts
+++ b/src/app/invoices/advanced-invoice/advanced-invoice.component.ts
@@ -134,6 +134,9 @@ export class AdvancedInvoiceComponent implements OnInit {
       buyerInfo: this.buyerInfo,
       invoiceItems: this.invoiceItems,
       paymentTerms: this.paymentTerms,
+      miscellaneous: {
+        builderId: 'app.request.network',
+      },
     });
 
     this.form = this.formBuilder.group({

--- a/src/app/invoices/home/home.component.ts
+++ b/src/app/invoices/home/home.component.ts
@@ -164,6 +164,8 @@ export class HomeComponent implements OnInit {
       }
     }
 
+    data['miscellaneous'] = { builderId: 'app.request.network' };
+
     const callback = response => {
       this.createLoading = false;
 


### PR DESCRIPTION
We can now track created requests on app.request.network 

note: for the regular request we don't use the rnf_invoice standard because there are checks throughout the code to detect rnf_invoices and show them as 'advanced invoices'. 