### PR TITLE
fix: added ID's back in for the PDF generation

### DIFF
--- a/src/app/invoices/request/request.component.html
+++ b/src/app/invoices/request/request.component.html
@@ -63,10 +63,10 @@
                   <div class="w-100 text-center fc-primary py-4 request-amount">
                     <div class="fs-14" style="font-style: italic;">AMOUNT</div>
                     <div class="fs-28 semi-bold" id="request-expected-amount">{{ amount }} {{ currency }}</div>
-                    <currency-converter *ngIf="amount && request.paymentTimestamp" [from]="currency" [to]="'USD'" [amount]="amount"
+                    <currency-converter *ngIf="amount && request.paymentTimestamp" id="amount-usd" [from]="currency" [to]="'USD'" [amount]="amount"
                             [timestamp]="request.paymentTimestamp">
                     </currency-converter>
-                    <currency-converter *ngIf="amount && request.createdTimestamp && !request.paymentTimestamp" [from]="currency" [to]="'USD'" [amount]="amount"
+                    <currency-converter *ngIf="amount && request.createdTimestamp && !request.paymentTimestamp" id="amount-usd" [from]="currency" [to]="'USD'" [amount]="amount"
                       [timestamp]="createdTimestamp">
                     </currency-converter>
                     <div *ngIf="request.status == 'paid'">

--- a/src/assets/js/receipt.js
+++ b/src/assets/js/receipt.js
@@ -112,7 +112,9 @@ $('#download-receipt').click(function () {
     centeredText(amount, amountValueY);
 
     doc.setFontSize(14);
-    centeredText(amountUSD, amountUsdValueY);
+    if (amountUSD) {
+        centeredText(amountUSD, amountUsdValueY);
+    }
 
     doc.save('RequestInvoice');
 


### PR DESCRIPTION
The id="amount-usd" is used in the PDF, as this was removed it wasn't adding in the USD amount to the PDF.