### PR TITLE
fix: pending request tab defaults to hidden on load

### DIFF
--- a/src/app/shared/pending-requests/pending-requests.component.html
+++ b/src/app/shared/pending-requests/pending-requests.component.html
@@ -1,4 +1,4 @@
-<div (click)="clickPendingRequestsTab()" class="pending-requests-float {{notificationCount != 0 || !hasBeenClicked ? '' : 'offset'}}">YOUR PENDING REQUESTS<i class="pending-notifications {{notificationCount == 0 ? 'no-notifications' : ''}}">{{notificationCount}}</i></div>
+<div (click)="clickPendingRequestsTab()" class="pending-requests-float {{notificationCount != 0 ? '' : 'offset'}}">YOUR PENDING REQUESTS<i class="pending-notifications {{notificationCount == 0 ? 'no-notifications' : ''}}">{{notificationCount}}</i></div>
 
 <div *ngIf="showPendingPopup" class="pending-request-popup">
     <i class="close" (click)="clickPendingRequestsTab()">&times;</i>

--- a/src/app/shared/pending-requests/pending-requests.component.ts
+++ b/src/app/shared/pending-requests/pending-requests.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { CookieService } from 'ngx-cookie-service';
-import { UtilService } from '../../util/util.service';
 
 @Component({
   selector: 'pending-requests',
@@ -16,7 +15,6 @@ export class PendingRequestsComponent implements OnInit {
 
   constructor(
     private cookieService: CookieService,
-    private utilService: UtilService,
   ) {
 
     this.checkForNotifications();

--- a/src/app/shared/pending-requests/pending-requests.component.ts
+++ b/src/app/shared/pending-requests/pending-requests.component.ts
@@ -12,7 +12,6 @@ export class PendingRequestsComponent implements OnInit {
   notificationCount = 0;
   broadcastingRequestCount = 0;
   showPendingPopup = false;
-  hasBeenClicked = false;
   requestList = [];
 
   constructor(
@@ -92,7 +91,6 @@ export class PendingRequestsComponent implements OnInit {
       });
       this.cookieService.set('processing_requests', JSON.stringify(updatedCookieList), 1);
     }
-    this.hasBeenClicked = true;
     this.showPendingPopup = !this.showPendingPopup;
   }
 


### PR DESCRIPTION
On initial load, hide the pending request tab. Before this change, it would only hide after an initial click. 