### PR TITLE
fix: type from 'canceled' to 'cancelled'

### DIFF
--- a/src/app/invoices/request/request.component.html
+++ b/src/app/invoices/request/request.component.html
@@ -324,7 +324,7 @@
                 <p class="semi-bold mb-2 fs-16">History</p>
                 <div *ngIf="request && request.events && request.events.length > 0">
                   <div *ngFor="let e of request.events" class="fs-14 d-flex mb-1 justify-content-between">
-                    <span>{{ spaceBeforeCapital(e.name) }} </span>
+                    <span>{{ spaceBeforeCapital(e.name) === 'Canceled' ? 'Cancelled' : spaceBeforeCapital(e.name) }} </span>
                     <span>{{ utilService.getAgeFromTimeStamp(e._meta.timestamp) }}</span>
                   </div>
                 </div>


### PR DESCRIPTION
This seems like a weird fix, but this is because the type 'canceled' comes from the library, not the app. 

I weighed up two options here and changing it on the library (as V1 is deprecated) might cause issues for outside builders, for exampple if they check against 'canceled'.

Because of this I just decided to fix in the UI 