### PR TITLE
feat: improved ledger experience

### DIFF
--- a/src/app/shared/account/account.component.html
+++ b/src/app/shared/account/account.component.html
@@ -42,37 +42,6 @@
       </div>
     </div>
   </ng-template>
-  <mat-menu #accountMenu="matMenu" [overlapTrigger]="false" class="mat-menu-custom">
-    <div *ngIf="web3Service.accountObservable | async as account; else accountLost">
-      <a routerLink="/search/{{ account }}" (click)="utilService.setSearchValue(account)" mat-menu-item>
-        <i class="fa fa-search" aria-hidden="true"></i>
-        <small>&nbsp;{{ account }}</small>
-      </a>
-      <hr class="m-0" style="border-color: #617B9F; opacity: 0.1;" />
-    </div>
-    <ng-template #accountLost>
-      <button class="d-flex align-items-center" (click)="web3Service.checkAndInstantiateWeb3()"
-        *ngIf="web3Service.metamask" mat-menu-item>
-        <img style="width: 20px; position: relative; top: -4px; margin: 0 0.5rem" src="assets/img/metamask-icon.png">
-        <span>&nbsp;Connect Metamask</span>
-      </button>
-    </ng-template>
-    <button class="d-flex align-items-center" (click)="openLedgerDialog()" mat-menu-item>
-      <img style="width: 36px; position: relative; top: -2px" src="assets/img/ledger-icon.png">
-      <span>&nbsp;Connect Ledger Nano S</span>
-    </button>
-    <button class="d-flex align-items-center" (click)="web3Service.checkAndInstantiateWeb3()"
-      *ngIf="(!web3Service.metamask || web3Service.ledgerConnected)" mat-menu-item>
-      <img style="width: 20px; position: relative; top: -4px; margin: 0 0.5rem" src="assets/img/metamask-icon.png">
-      <span>&nbsp;Connect Metamask</span>
-    </button>
-    <a class="fs-14 d-flex align-items-center"
-      href="https://chrome.google.com/webstore/detail/metamask/nkbihfbeogaeaoehlefnkodbefgpgknn" target="_blank"
-      *ngIf="!web3Service.metamask" mat-menu-item>
-      <img style="width: 20px; position: relative; top: -4px; margin: 0 0.5rem" src="assets/img/metamask-icon.png">
-      <span>&nbsp;Download Metamask</span>
-    </a>
-  </mat-menu>
 </button>
 
 
@@ -85,15 +54,25 @@
   </h2>
 
   <div *ngIf="web3Service.accountObservable | async as account; else accountLost">
-    <button class="d-flex align-items-center" (click)="web3Service.checkAndInstantiateWeb3()"
-      *ngIf="web3Service.metamask">
+    <button class="d-flex align-items-center"
+      *ngIf="web3Service.metamask && !web3Service.ledgerConnected">
       <img src="assets/img/metamask-icon-colour.png">
+      <span>{{ account.substring(0,14) }}.a..{{ account.substring(28,42) }}</span>
+    </button>
+    <button class="d-flex align-items-center" (click)="openLedgerDialog()"
+      *ngIf="web3Service.metamask && !web3Service.ledgerConnected">
+      <img style="width: 36px;" src="assets/img/ledger-icon-colour.png">
+      <span>&nbsp;Connect Ledger Nano S</span> 
+    </button>
+    <button class="d-flex align-items-center"
+      *ngIf="web3Service.ledgerConnected">
+      <img style="width: 36px;" src="assets/img/ledger-icon-colour.png">
       <span>{{ account.substring(0,14) }}...{{ account.substring(28,42) }}</span>
     </button>
     <button class="d-flex align-items-center" (click)="web3Service.checkAndInstantiateWeb3()"
       *ngIf="web3Service.ledgerConnected">
-      <img style="width: 36px;" src="assets/img/ledger-icon-colour.png">
-      <span>{{ account.substring(0,14) }}...{{ account.substring(28,42) }}</span>
+      <img src="assets/img/metamask-icon-colour.png">
+      <span>&nbsp;Connect Metamask</span>
     </button>
   </div>
   <ng-template #accountLost>
@@ -114,5 +93,6 @@
   </ng-template>
 
   <p style="text-align: center; margin-top: 36px;">Is your wallet not supported?<br />
-    <a style="display: block; margin-top: 6px; color: #00E6A0;" target="_blank" href="https://share.hsforms.com/1SUDFJxJySliSedFiwifsfw2nz19">Let us know</a></p>
+    <a style="display: block; margin-top: 6px; color: #00E6A0;" target="_blank"
+      href="https://share.hsforms.com/1SUDFJxJySliSedFiwifsfw2nz19">Let us know</a></p>
 </div>

--- a/src/app/shared/account/account.component.ts
+++ b/src/app/shared/account/account.component.ts
@@ -15,7 +15,15 @@ export class AccountComponent {
     public web3Service: Web3Service,
     private dialog: MatDialog,
     private utilService: UtilService
-  ) {}
+  ) {
+    this.web3Service.accountLoadingObservable.subscribe(value => {
+      if (value == 'enableWeb3' || value == 'noWeb3') {
+        this.openModal();
+      } else {
+        this.closeModal();
+      }
+    });
+  }
 
   public accountModalOpen = false;
 

--- a/src/app/util/web3.service.ts
+++ b/src/app/util/web3.service.ts
@@ -321,7 +321,6 @@ export class Web3Service {
 
   private async enableWeb3() {
     if (typeof window.ethereum !== 'undefined') {
-      console.log(window.ethereum);
       if (window.ethereum.selectedAddress) {
         window.web3 = new Web3(window.ethereum);
       } else {


### PR DESCRIPTION
When wallet is validated, get served a popup that allows you to click on the other wallet options (Ledger, Metamask).

When a user first lands on app.r.n, they should be served the wallet popup asking them which wallet they would like to validate.

After I validate my wallet address, I should be redirected to the main page of the app

Ledger being overridden by Metamask; not allowing access to dashboard